### PR TITLE
优化Android平台updateState的时机

### DIFF
--- a/packages/nested-scroll/android/src/main/java/com/reactnative/nestedscroll/NestedScrollView.java
+++ b/packages/nested-scroll/android/src/main/java/com/reactnative/nestedscroll/NestedScrollView.java
@@ -64,26 +64,29 @@ public class NestedScrollView extends androidx.core.widget.NestedScrollView impl
 			final int myConsumed = getScrollY() - oldScrollY;
 			consumed[1] += myConsumed;
 		}
-
-		if (mStateWrapper != null) {
-			ReadableMap currentState = mStateWrapper.getStateData();
-			double currentOffsetY = 0;
-			if (currentState != null && currentState.hasKey("contentOffsetY")) {
-				currentOffsetY = currentState.getDouble("contentOffsetY");
-			}
-			final int newOffsetY = (int) toDIPFromPixel(getScrollY());
-
-			if (Math.abs(currentOffsetY - newOffsetY) > 0.1) {
-				WritableMap map = Arguments.createMap();
-				FLog.i(TAG, "updateState contentOffsetY : " + newOffsetY);
-				map.putDouble("contentOffsetY", newOffsetY);
-				mStateWrapper.updateState(map);
-			}
-		}
-
 	}
 
-	@Override
+    @Override
+    protected void onScrollChanged(int l, int t, int oldl, int oldt) {
+        super.onScrollChanged(l, t, oldl, oldt);
+        if (mStateWrapper != null) {
+            ReadableMap currentState = mStateWrapper.getStateData();
+            double currentOffsetY = 0;
+            if (currentState != null && currentState.hasKey("contentOffsetY")) {
+                currentOffsetY = currentState.getDouble("contentOffsetY");
+            }
+            final int newOffsetY = (int) toDIPFromPixel(getScrollY());
+
+            if (Math.abs(currentOffsetY - newOffsetY) > 0.1) {
+                WritableMap map = Arguments.createMap();
+                FLog.i(TAG, "updateState contentOffsetY : " + newOffsetY);
+                map.putDouble("contentOffsetY", newOffsetY);
+                mStateWrapper.updateState(map);
+            }
+        }
+    }
+
+    @Override
 	public boolean onNestedPreFling(@NonNull View target, float velocityX, float velocityY) {
 		boolean consumed = super.onNestedPreFling(target, velocityX, velocityY);
 		if (!consumed) {


### PR DESCRIPTION
只在 `onNestedPreScroll` 里更新，只捕捉到了“手指推着屏幕走”的位移，而忽略了惯性（Fling）和系统自动修正产生的位移。现在换成`onScrollChanged`方式，官方的ScrollView也是这个方式  https://github.com/facebook/react-native/blob/e7e87d78c4630e33a4f94b5480f15def3196ab0b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java#L567