### PR TITLE
修复overlay里面的passThroughTouches取值错误

### DIFF
--- a/packages/overlay/ios/RNOverlayModule.mm
+++ b/packages/overlay/ios/RNOverlayModule.mm
@@ -80,10 +80,11 @@ RCT_EXPORT_MODULE(OverlayHost)
 	  @"left" : @(safeAreaInsets.left),
 	};
 
+	std::optional<bool> passThrough = options.passThroughTouches();
 	NSDictionary *props = @{
 		@"insets": insets,
 		@"overlayId": @(options.overlayId()),
-		@"passThroughTouches": @((BOOL)options.passThroughTouches())
+		@"passThroughTouches": @(passThrough.has_value() ? passThrough.value() : false)
 	};
 	[overlay show:props options:props];
 }


### PR DESCRIPTION
之前的写法会取值错误，即使`Overlay.show('__overlay_toast__', { passThroughTouches:false, overlayId: key });`这里传入的是false,在ios里面获取的一直都是true